### PR TITLE
Implement Hype Em Up marketing site

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# chains
+# Hype Em Up
+
+Production-ready marketing site for **hypeemup.com** built with Next.js 14 (App Router), React 18, TypeScript, and Tailwind CSS.
+
+## Features
+
+- Immersive hero with conversion metrics and CTA
+- Detailed case study and capabilities sections highlighting experiential marketing services
+- Pricing tiers with highlighted flagship offering
+- Testimonials and FAQ sections populated from structured data
+- Contact form with server-side validation via a Next.js API route
+- Responsive layout optimized for modern browsers and devices
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Visit [http://localhost:3000](http://localhost:3000) to view the site locally.
+
+## Scripts
+
+- `npm run dev` – start the local development server
+- `npm run build` – create a production build
+- `npm run start` – run the production build locally
+- `npm run lint` – run ESLint checks
+
+## Deployment
+
+The application is ready to deploy on platforms that support Next.js (Vercel, Netlify, etc.). Ensure environment variables for downstream integrations are configured before enabling the contact endpoint to connect with your CRM or email service.

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+const EMAIL_REGEX = /^(?:[a-zA-Z0-9_'^&/+-])+(?:\.(?:[a-zA-Z0-9_'^&/+-])+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null) as Record<string, string | undefined> | null;
+
+  if (!body) {
+    return NextResponse.json({ message: "Invalid request." }, { status: 400 });
+  }
+
+  const name = (body.name ?? "").trim();
+  const email = (body.email ?? "").trim().toLowerCase();
+  const company = (body.company ?? "").trim();
+  const message = (body.message ?? "").trim();
+
+  if (name.length < 2) {
+    return NextResponse.json({ message: "Please provide your full name." }, { status: 400 });
+  }
+
+  if (!EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ message: "Please provide a valid work email." }, { status: 400 });
+  }
+
+  if (message.length < 10) {
+    return NextResponse.json({ message: "Share a bit more about your launch so we can prepare." }, { status: 400 });
+  }
+
+  // In production we would forward to a CRM or email provider.
+  console.info("New hype audit request", {
+    name,
+    email,
+    company,
+    message: message.slice(0, 500)
+  });
+
+  return NextResponse.json({ message: "Thanks! A producer will reach out within one business day." });
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -12,6 +12,7 @@ export async function POST(request: Request) {
   const name = (body.name ?? "").trim();
   const email = (body.email ?? "").trim().toLowerCase();
   const company = (body.company ?? "").trim();
+  const launchDate = (body.launchDate ?? "").trim();
   const message = (body.message ?? "").trim();
 
   if (name.length < 2) {
@@ -26,11 +27,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ message: "Share a bit more about your launch so we can prepare." }, { status: 400 });
   }
 
+  if (launchDate.length > 0 && launchDate.length > 60) {
+    return NextResponse.json({ message: "Launch timing looks a bit long—keep it under 60 characters." }, { status: 400 });
+  }
+
   // In production we would forward to a CRM or email provider.
   console.info("New hype audit request", {
     name,
     email,
     company,
+    launchDate,
     message: message.slice(0, 500)
   });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,44 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: #0f0f1a;
+  color: #f8f9ff;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.bg-grid {
+  background-image: radial-gradient(rgba(108, 92, 231, 0.3) 1px, transparent 0);
+  background-size: 24px 24px;
+}
+
+.section-container {
+  @apply mx-auto w-full max-w-6xl px-6 py-24 sm:px-8;
+}
+
+.card {
+  @apply rounded-3xl border border-white/10 bg-white/5 p-8 shadow-glow transition hover:border-primary/60 hover:shadow-glow;
+}
+
+.text-gradient {
+  background: linear-gradient(135deg, #6c5ce7 0%, #ff6b6b 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import { Manrope } from "next/font/google";
+import "./globals.css";
+import { Header } from "@/components/header";
+import { Footer } from "@/components/footer";
+
+const sans = Manrope({
+  subsets: ["latin"],
+  variable: "--font-sans"
+});
+
+export const metadata: Metadata = {
+  title: "Hype Em Up | Launch unforgettable brand moments",
+  description:
+    "Hype Em Up blends experiential marketing with data-backed strategy so high-growth brands can launch unforgettable campaigns and capture measurable demand.",
+  metadataBase: new URL("https://hypeemup.com"),
+  openGraph: {
+    title: "Hype Em Up",
+    description:
+      "Experiential marketing studio for venture-backed brands looking to turn attention into action.",
+    url: "https://hypeemup.com",
+    siteName: "Hype Em Up",
+    images: [
+      {
+        url: "/og.svg",
+        width: 1200,
+        height: 630,
+        alt: "Hype Em Up hero graphic"
+      }
+    ],
+    locale: "en_US",
+    type: "website"
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Hype Em Up",
+    description:
+      "Experiential marketing studio for venture-backed brands looking to turn attention into action.",
+    images: ["/og.svg"],
+    creator: "@hypeemup"
+  }
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={`${sans.variable} bg-[#050510] text-white antialiased`}>
+        <div className="relative mx-auto max-w-[1440px] overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(108,92,231,0.35),_transparent_60%)]" />
+          <Header />
+          <main>{children}</main>
+          <Footer />
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,23 @@
+import { Hero } from "@/components/hero";
+import { Work } from "@/components/work";
+import { Approach } from "@/components/approach";
+import { Testimonials } from "@/components/testimonials";
+import { Pricing } from "@/components/pricing";
+import { FAQ } from "@/components/faq";
+import { Contact } from "@/components/contact";
+import { CTA } from "@/components/cta";
+
+export default function HomePage() {
+  return (
+    <>
+      <Hero />
+      <Work />
+      <Approach />
+      <Testimonials />
+      <Pricing />
+      <FAQ />
+      <Contact />
+      <CTA />
+    </>
+  );
+}

--- a/components/approach.tsx
+++ b/components/approach.tsx
@@ -1,0 +1,44 @@
+import { processSteps } from "@/lib/data";
+
+export function Approach() {
+  return (
+    <section id="approach" className="section-container">
+      <div className="grid gap-16 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+        <div className="space-y-6">
+          <span className="text-sm uppercase tracking-[0.3em] text-white/50">Approach</span>
+          <h2 className="text-3xl font-semibold text-white sm:text-4xl">An eight-week sprint with measurable checkpoints</h2>
+          <p className="text-lg text-white/70">
+            We orchestrate cross-functional pods that move from narrative strategy to production and amplification without the typical agency silos.
+          </p>
+          <div className="rounded-[32px] border border-primary/20 bg-primary/10 p-8 text-white/80">
+            <h3 className="text-xl font-semibold text-white">Your growth partner on speed dial</h3>
+            <p className="mt-3 text-sm text-white/70">
+              Async updates twice a week, Miro boards for alignment, and live dashboards with budget and KPI tracking keep your team confident from start to finish.
+            </p>
+          </div>
+        </div>
+        <ol className="space-y-6">
+          {processSteps.map((step, index) => (
+            <li
+              key={step.title}
+              className="relative rounded-[28px] border border-white/10 bg-white/5 p-6"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <span className="text-sm font-semibold uppercase tracking-[0.2em] text-white/50">
+                    Phase {index + 1}
+                  </span>
+                  <h3 className="mt-2 text-2xl font-semibold text-white">{step.title}</h3>
+                  <p className="mt-3 text-sm text-white/70">{step.description}</p>
+                </div>
+                <span className="rounded-full border border-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white/60">
+                  {step.duration}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -25,26 +25,31 @@ export function Contact() {
       message: formData.get("message")?.toString() ?? ""
     };
 
-    const response = await fetch("/api/subscribe", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload)
-    });
-
-    let result: { message?: string } = {};
     try {
-      result = await response.json();
+      const response = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+
+      let result: { message?: string } = {};
+      try {
+        result = await response.json();
+      } catch (error) {
+        console.error("Failed to parse response", error);
+      }
+
+      if (!response.ok) {
+        setFormState({ status: "error", message: result.message ?? "Something went wrong." });
+        return;
+      }
+
+      form.reset();
+      setFormState({ status: "success", message: result.message ?? "Thanks! We'll be in touch." });
     } catch (error) {
-      console.error("Failed to parse response", error);
+      console.error("Request failed", error);
+      setFormState({ status: "error", message: "We couldn't send your request. Please try again." });
     }
-
-    if (!response.ok) {
-      setFormState({ status: "error", message: result.message ?? "Something went wrong." });
-      return;
-    }
-
-    form.reset();
-    setFormState({ status: "success", message: result.message ?? "Thanks! We'll be in touch." });
   }
 
   return (
@@ -73,6 +78,7 @@ export function Contact() {
         </div>
         <form
           onSubmit={handleSubmit}
+          aria-busy={formState.status === "loading"}
           className="space-y-5 rounded-[32px] border border-white/10 bg-white/5 p-8 shadow-lg shadow-primary/20"
         >
           <div className="grid gap-5 sm:grid-cols-2">
@@ -132,15 +138,17 @@ export function Contact() {
           >
             {formState.status === "loading" ? "Scheduling..." : "Request my audit"}
           </button>
-          {formState.message && (
-            <p
-              className={`text-sm ${
-                formState.status === "error" ? "text-red-400" : "text-green-400"
-              }`}
-            >
-              {formState.message}
-            </p>
-          )}
+          <div aria-live="polite" role="status">
+            {formState.message && (
+              <p
+                className={`text-sm ${
+                  formState.status === "error" ? "text-red-400" : "text-green-400"
+                }`}
+              >
+                {formState.message}
+              </p>
+            )}
+          </div>
         </form>
       </div>
     </section>

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+interface FormState {
+  status: "idle" | "loading" | "success" | "error";
+  message: string;
+}
+
+export function Contact() {
+  const [formState, setFormState] = useState<FormState>({ status: "idle", message: "" });
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    setFormState({ status: "loading", message: "" });
+
+    const payload = {
+      name: formData.get("name")?.toString() ?? "",
+      email: formData.get("email")?.toString() ?? "",
+      company: formData.get("company")?.toString() ?? "",
+      launchDate: formData.get("launchDate")?.toString() ?? "",
+      message: formData.get("message")?.toString() ?? ""
+    };
+
+    const response = await fetch("/api/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    let result: { message?: string } = {};
+    try {
+      result = await response.json();
+    } catch (error) {
+      console.error("Failed to parse response", error);
+    }
+
+    if (!response.ok) {
+      setFormState({ status: "error", message: result.message ?? "Something went wrong." });
+      return;
+    }
+
+    form.reset();
+    setFormState({ status: "success", message: result.message ?? "Thanks! We'll be in touch." });
+  }
+
+  return (
+    <section id="contact" className="section-container">
+      <div className="grid gap-16 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+        <div className="space-y-6">
+          <span className="text-sm uppercase tracking-[0.3em] text-white/50">Book a Hype Audit</span>
+          <h2 className="text-3xl font-semibold text-white sm:text-4xl">Let’s design your next unforgettable launch</h2>
+          <p className="text-lg text-white/70">
+            Tell us about the moment you want to create. We’ll respond within one business day with next steps and available sprint dates.
+          </p>
+          <ul className="space-y-3 text-sm text-white/60">
+            <li className="flex items-start gap-3">
+              <span className="mt-1 h-2 w-2 rounded-full bg-accent" />
+              <span>Full campaign roadmap in under 14 days.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-1 h-2 w-2 rounded-full bg-accent" />
+              <span>Dedicated producer, creative director, and performance analyst.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-1 h-2 w-2 rounded-full bg-accent" />
+              <span>Transparent pricing with results-tied commitment.</span>
+            </li>
+          </ul>
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-5 rounded-[32px] border border-white/10 bg-white/5 p-8 shadow-lg shadow-primary/20"
+        >
+          <div className="grid gap-5 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Name
+              <input
+                required
+                name="name"
+                type="text"
+                placeholder="Sasha Kim"
+                className="rounded-2xl border border-white/10 bg-[#0a0a15] px-4 py-3 text-white placeholder:text-white/30 focus:border-primary focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Work email
+              <input
+                required
+                name="email"
+                type="email"
+                placeholder="you@company.com"
+                className="rounded-2xl border border-white/10 bg-[#0a0a15] px-4 py-3 text-white placeholder:text-white/30 focus:border-primary focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Company
+              <input
+                name="company"
+                type="text"
+                placeholder="Nova Athletics"
+                className="rounded-2xl border border-white/10 bg-[#0a0a15] px-4 py-3 text-white placeholder:text-white/30 focus:border-primary focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Target launch timing
+              <input
+                name="launchDate"
+                type="text"
+                placeholder="Q3 2024"
+                className="rounded-2xl border border-white/10 bg-[#0a0a15] px-4 py-3 text-white placeholder:text-white/30 focus:border-primary focus:outline-none"
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-2 text-sm text-white/70">
+            What does success look like?
+            <textarea
+              name="message"
+              rows={4}
+              required
+              placeholder="We’re launching a connected fitness product and need an activation that drives 5k preorders."
+              className="rounded-2xl border border-white/10 bg-[#0a0a15] px-4 py-3 text-white placeholder:text-white/30 focus:border-primary focus:outline-none"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={formState.status === "loading"}
+            className="inline-flex w-full items-center justify-center rounded-full bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/40 transition hover:-translate-y-0.5 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {formState.status === "loading" ? "Scheduling..." : "Request my audit"}
+          </button>
+          {formState.message && (
+            <p
+              className={`text-sm ${
+                formState.status === "error" ? "text-red-400" : "text-green-400"
+              }`}
+            >
+              {formState.message}
+            </p>
+          )}
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export function CTA() {
+  return (
+    <section className="section-container">
+      <div className="relative overflow-hidden rounded-[40px] border border-primary/40 bg-gradient-to-br from-primary/40 via-accent/30 to-transparent p-12 text-center shadow-xl shadow-primary/30">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.15),_transparent_55%)]" />
+        <div className="relative space-y-6">
+          <span className="text-sm uppercase tracking-[0.3em] text-white/70">Let’s build hype</span>
+          <h2 className="text-3xl font-semibold text-white sm:text-4xl">Ready to architect your next moment?</h2>
+          <p className="mx-auto max-w-3xl text-lg text-white/80">
+            We help ambitious teams orchestrate culture-driving launches that deliver measurable revenue. Tell us your goal and we’ll map the path.
+          </p>
+          <div className="flex flex-col justify-center gap-4 sm:flex-row">
+            <Link
+              href="#contact"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/40 transition hover:-translate-y-0.5 hover:shadow-xl"
+            >
+              Book a hype audit
+            </Link>
+            <Link
+              href="mailto:hello@hypeemup.com"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-8 py-4 text-base font-semibold text-white/80 transition hover:border-primary hover:text-primary"
+            >
+              Email the founders
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/faq.tsx
+++ b/components/faq.tsx
@@ -1,0 +1,30 @@
+import { faqs } from "@/lib/data";
+
+export function FAQ() {
+  return (
+    <section id="faqs" className="section-container">
+      <div className="mx-auto max-w-3xl text-center">
+        <span className="text-sm uppercase tracking-[0.3em] text-white/50">FAQs</span>
+        <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">Answers before we hit go</h2>
+        <p className="mt-4 text-lg text-white/70">
+          Here is what teams ask us before we start architecting hype together.
+        </p>
+      </div>
+      <div className="mt-16 space-y-6">
+        {faqs.map((faq) => (
+          <details
+            key={faq.question}
+            className="group rounded-[28px] border border-white/10 bg-white/5 p-6"
+          >
+            <summary className="cursor-pointer text-left text-lg font-semibold text-white">
+              {faq.question}
+            </summary>
+            <p className="mt-4 text-sm text-white/70 group-open:animate-fadeIn">
+              {faq.answer}
+            </p>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="section-container border-t border-white/10 text-sm text-white/60">
+      <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+        <p>&copy; {new Date().getFullYear()} Hype Em Up. All rights reserved.</p>
+        <div className="flex items-center gap-5">
+          <Link
+            href="mailto:hello@hypeemup.com"
+            className="transition hover:text-white"
+          >
+            hello@hypeemup.com
+          </Link>
+          <Link href="https://www.linkedin.com" className="transition hover:text-white">
+            LinkedIn
+          </Link>
+          <Link href="https://www.instagram.com" className="transition hover:text-white">
+            Instagram
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import Link from "next/link";
+import { Dialog, Transition } from "@headlessui/react";
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
+import { navigation } from "@/lib/data";
+
+export function Header() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 backdrop-blur-md">
+      <div className="section-container flex items-center justify-between py-6">
+        <Link href="#top" className="flex items-center gap-3 text-lg font-semibold tracking-tight">
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-xl font-bold text-primary-foreground shadow-glow">
+            HEU
+          </span>
+          <div className="hidden sm:flex sm:flex-col">
+            <span className="text-sm uppercase text-white/60">Hype Em Up</span>
+            <span className="text-base text-white">Experiential Studio</span>
+          </div>
+        </Link>
+        <nav className="hidden items-center gap-8 text-sm font-medium text-white/80 md:flex">
+          {navigation.map((item) => (
+            <Link
+              key={item.name}
+              href={item.href}
+              className="transition hover:text-white"
+            >
+              {item.name}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3">
+          <Link
+            href="#contact"
+            className="hidden rounded-full bg-primary px-5 py-3 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/40 transition hover:-translate-y-0.5 hover:shadow-xl md:inline-flex"
+          >
+            Book a Hype Audit
+          </Link>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/10 text-white transition hover:border-primary hover:text-primary md:hidden"
+            aria-label="Open navigation"
+          >
+            <Bars3Icon className="h-6 w-6" />
+          </button>
+        </div>
+      </div>
+
+      <Transition show={open} as={Fragment}>
+        <Dialog as="div" className="relative z-50 md:hidden" onClose={setOpen}>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-200"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-150"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black/60" />
+          </Transition.Child>
+
+          <div className="fixed inset-y-0 right-0 w-full max-w-sm overflow-y-auto bg-[#050510] px-6 py-8 sm:ring-1 sm:ring-white/10">
+            <div className="flex items-center justify-between">
+              <Link
+                href="#top"
+                className="flex items-center gap-3 text-lg font-semibold tracking-tight"
+                onClick={() => setOpen(false)}
+              >
+                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-accent text-xl font-bold text-primary-foreground shadow-glow">
+                  HEU
+                </span>
+                <span>Hype Em Up</span>
+              </Link>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-full border border-white/10 p-3 text-white"
+                aria-label="Close navigation"
+              >
+                <XMarkIcon className="h-6 w-6" />
+              </button>
+            </div>
+            <div className="mt-8 space-y-6 text-lg">
+              {navigation.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  onClick={() => setOpen(false)}
+                  className="block rounded-2xl bg-white/5 px-4 py-3 font-semibold text-white/80 transition hover:bg-white/10 hover:text-white"
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
+            <Link
+              href="#contact"
+              onClick={() => setOpen(false)}
+              className="mt-10 inline-flex w-full items-center justify-center rounded-full bg-primary px-5 py-3 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/40 transition hover:-translate-y-0.5 hover:shadow-xl"
+            >
+              Book a Hype Audit
+            </Link>
+          </div>
+        </Dialog>
+      </Transition>
+    </header>
+  );
+}

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,0 +1,82 @@
+import { metrics, clients } from "@/lib/data";
+import Link from "next/link";
+
+export function Hero() {
+  return (
+    <section id="top" className="section-container pt-10">
+      <div className="grid gap-16 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <div className="space-y-8">
+          <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+            Experiential + Lifecycle + Analytics
+          </span>
+          <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+            Launch unforgettable brand moments that convert attention into action.
+          </h1>
+          <p className="text-lg text-white/70 sm:text-xl">
+            Hype Em Up is the experiential marketing studio that architects culture-driving launches for product-led teams. We combine strategy, production, and performance measurement in one agile crew.
+          </p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <Link
+              href="#contact"
+              className="inline-flex items-center justify-center rounded-full bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/40 transition hover:-translate-y-0.5 hover:shadow-xl"
+            >
+              Plan my launch
+            </Link>
+            <Link
+              href="#work"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-8 py-4 text-base font-semibold text-white/80 transition hover:border-primary hover:text-primary"
+            >
+              View playbooks
+            </Link>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-3">
+            {metrics.map((metric) => (
+              <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-6">
+                <p className="text-3xl font-semibold text-white">{metric.value}</p>
+                <p className="mt-2 text-sm font-medium uppercase tracking-wide text-white/50">
+                  {metric.label}
+                </p>
+                <p className="mt-2 text-sm text-white/60">{metric.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="relative">
+          <div className="absolute inset-0 -translate-x-6 rounded-[40px] bg-gradient-to-br from-primary/60 via-accent/40 to-transparent blur-3xl" />
+          <div className="relative rounded-[40px] border border-white/10 bg-white/[0.04] p-10 shadow-2xl shadow-primary/20">
+            <div className="space-y-6">
+              <div className="rounded-3xl bg-white/5 p-6">
+                <p className="text-sm uppercase tracking-[0.3em] text-white/50">Playbooks</p>
+                <h2 className="mt-3 text-2xl font-semibold text-white">Launch systems engineered to scale</h2>
+                <p className="mt-3 text-sm text-white/60">
+                  Always-on hype pods, conversion-driven storytelling, and measurement frameworks built for the next board meeting.
+                </p>
+              </div>
+              <div className="rounded-3xl bg-white/5 p-6">
+                <p className="text-sm uppercase tracking-[0.3em] text-white/50">Trusted by</p>
+                <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-white/70 sm:grid-cols-3">
+                  {clients.map((client) => (
+                    <span
+                      key={client}
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center"
+                    >
+                      {client}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-3xl bg-gradient-to-br from-white/10 via-white/5 to-transparent p-6">
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+                  Guarantee
+                </p>
+                <p className="mt-3 text-base text-white/80">
+                  We align on pipeline goals up front. If we miss the KPIs we commit to, we stay on until we hit them.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -1,0 +1,50 @@
+import { pricingTiers } from "@/lib/data";
+import Link from "next/link";
+
+export function Pricing() {
+  return (
+    <section id="pricing" className="section-container">
+      <div className="mx-auto max-w-3xl text-center">
+        <span className="text-sm uppercase tracking-[0.3em] text-white/50">Pricing</span>
+        <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">Flexible retainers matched to your launch ambition</h2>
+        <p className="mt-4 text-lg text-white/70">
+          Choose a program that fits your launch velocity. Every tier can be tailored with add-ons like PR amplification, paid media, or community ops.
+        </p>
+      </div>
+      <div className="mt-16 grid gap-8 lg:grid-cols-3">
+        {pricingTiers.map((tier) => (
+          <div
+            key={tier.name}
+            className={`rounded-[32px] border p-8 ${
+              tier.highlighted
+                ? "border-primary/60 bg-gradient-to-br from-primary/20 via-white/5 to-transparent shadow-xl shadow-primary/30"
+                : "border-white/10 bg-white/5"
+            }`}
+          >
+            <span className="text-sm uppercase tracking-[0.3em] text-white/50">{tier.name}</span>
+            <p className="mt-4 text-4xl font-semibold text-white">{tier.price}</p>
+            <p className="mt-3 text-sm text-white/70">{tier.description}</p>
+            <ul className="mt-6 space-y-3 text-sm text-white/60">
+              {tier.items.map((item) => (
+                <li key={item} className="flex items-start gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-primary" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <Link
+              href="#contact"
+              className={`mt-8 inline-flex w-full items-center justify-center rounded-full border px-6 py-3 text-sm font-semibold transition ${
+                tier.highlighted
+                  ? "border-transparent bg-primary text-primary-foreground shadow-lg shadow-primary/40 hover:-translate-y-0.5 hover:shadow-xl"
+                  : "border-white/20 text-white/80 hover:border-primary hover:text-primary"
+              }`}
+            >
+              {tier.highlighted ? "Talk to a producer" : "Schedule a fit call"}
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -1,0 +1,31 @@
+import { testimonials } from "@/lib/data";
+
+export function Testimonials() {
+  return (
+    <section id="testimonials" className="section-container">
+      <div className="mx-auto max-w-3xl text-center">
+        <span className="text-sm uppercase tracking-[0.3em] text-white/50">Testimonials</span>
+        <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">Revenue leaders trust Hype Em Up to deliver launches that pay for themselves</h2>
+        <p className="mt-4 text-lg text-white/70">
+          From DTC to B2B SaaS, marketing teams rely on us to build experiences their customers never forget.
+        </p>
+      </div>
+      <div className="mt-16 grid gap-8 lg:grid-cols-3">
+        {testimonials.map((testimonial) => (
+          <figure
+            key={testimonial.author}
+            className="flex h-full flex-col justify-between rounded-[28px] border border-white/10 bg-white/5 p-8"
+          >
+            <blockquote className="text-base text-white/80">
+              “{testimonial.quote}”
+            </blockquote>
+            <figcaption className="mt-6 text-sm text-white/60">
+              <span className="block font-semibold text-white">{testimonial.author}</span>
+              {testimonial.role}
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/work.tsx
+++ b/components/work.tsx
@@ -20,7 +20,7 @@ export function Work() {
             <div className="absolute -top-16 right-8 h-40 w-40 rounded-full bg-gradient-to-br from-primary/50 via-accent/40 to-transparent blur-3xl" />
             <div className="relative space-y-5">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-base font-semibold text-white/70">
-                0{index + 1}
+                {String(index + 1).padStart(2, "0")}
               </span>
               <h3 className="text-2xl font-semibold text-white">{section.title}</h3>
               <p className="text-sm text-white/70">{section.description}</p>

--- a/components/work.tsx
+++ b/components/work.tsx
@@ -1,0 +1,69 @@
+import { featureSections } from "@/lib/data";
+import Image from "next/image";
+
+export function Work() {
+  return (
+    <section id="work" className="section-container">
+      <div className="space-y-6 text-center">
+        <span className="text-sm uppercase tracking-[0.3em] text-white/50">Recent Systems</span>
+        <h2 className="text-3xl font-semibold text-white sm:text-4xl">Playbooks that turn momentum into pipeline</h2>
+        <p className="mx-auto max-w-3xl text-lg text-white/70">
+          Every engagement connects IRL experiences with digital journeys, ensuring that hype is architected, activated, and measured.
+        </p>
+      </div>
+      <div className="mt-16 grid gap-10 lg:grid-cols-3">
+        {featureSections.map((section, index) => (
+          <article
+            key={section.title}
+            className="relative overflow-hidden rounded-[32px] border border-white/10 bg-white/5 p-8 shadow-lg shadow-primary/20"
+          >
+            <div className="absolute -top-16 right-8 h-40 w-40 rounded-full bg-gradient-to-br from-primary/50 via-accent/40 to-transparent blur-3xl" />
+            <div className="relative space-y-5">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-base font-semibold text-white/70">
+                0{index + 1}
+              </span>
+              <h3 className="text-2xl font-semibold text-white">{section.title}</h3>
+              <p className="text-sm text-white/70">{section.description}</p>
+              <ul className="space-y-3 text-sm text-white/60">
+                {section.items.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-accent" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        ))}
+      </div>
+      <div className="mt-16 grid gap-6 lg:grid-cols-2">
+        <div className="rounded-[32px] border border-white/10 bg-white/5 p-8">
+          <h3 className="text-2xl font-semibold text-white">Drop Launch: Nova Athletics x Shopify</h3>
+          <p className="mt-4 text-sm text-white/70">
+            Integrated pop-up and digital drop that sold out 12k units in 36 hours. Lifecycle flows captured 18k new subscribers and converted 27% to purchase within 14 days.
+          </p>
+          <Image
+            src="/case-nova.svg"
+            alt="Nova Athletics case study"
+            width={800}
+            height={520}
+            className="mt-6 h-64 w-full rounded-3xl object-cover"
+          />
+        </div>
+        <div className="rounded-[32px] border border-white/10 bg-white/5 p-8">
+          <h3 className="text-2xl font-semibold text-white">Product Beta: PulsePay Founders Circle</h3>
+          <p className="mt-4 text-sm text-white/70">
+            Invitation-only beta with experiential touchpoints that doubled qualified pipeline. Dashboard instrumentation helped the team close enterprise deals 40% faster.
+          </p>
+          <Image
+            src="/case-pulse.svg"
+            alt="PulsePay activation"
+            width={800}
+            height={520}
+            className="mt-6 h-64 w-full rounded-3xl object-cover"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,172 @@
+export const navigation = [
+  { name: "Work", href: "#work" },
+  { name: "Approach", href: "#approach" },
+  { name: "Pricing", href: "#pricing" },
+  { name: "Testimonials", href: "#testimonials" },
+  { name: "FAQs", href: "#faqs" }
+];
+
+export const metrics = [
+  {
+    label: "Campaign ROI",
+    value: "412%",
+    description: "Average return on multi-channel launch activations."
+  },
+  {
+    label: "Audience Growth",
+    value: "3.2x",
+    description: "Avg. subscriber lift after integrated hype cycles."
+  },
+  {
+    label: "Conversion Rate",
+    value: "28%",
+    description: "Opt-in rate from experiential funnel design."
+  }
+];
+
+export const clients = [
+  "Lumen Labs",
+  "Nova Athletics",
+  "PulsePay",
+  "Aether Studios",
+  "Northstar Apps",
+  "Quantum Audio"
+];
+
+export const featureSections = [
+  {
+    title: "Strategy that ships experiences",
+    description:
+      "We partner from positioning to post-launch analytics so your event, drop, or beta actually ladders into revenue KPIs.",
+    items: [
+      "Narrative & GTM architecture",
+      "Creator & partner sourcing",
+      "Lifecycle and retention flows"
+    ]
+  },
+  {
+    title: "Production without the headache",
+    description:
+      "Our producers orchestrate vendors, budget, and compliance while our creative team keeps your brand world consistent across touchpoints.",
+    items: [
+      "Full-service experiential production",
+      "Digital companion microsites",
+      "On-site staffing & run of show"
+    ]
+  },
+  {
+    title: "Measurement you can ship to the board",
+    description:
+      "From QR to CRM, every activation is instrumented. Expect dashboards that tie hype to pipeline in real time.",
+    items: [
+      "Attribution dashboards",
+      "CRM integration",
+      "Executive recap & learnings"
+    ]
+  }
+];
+
+export const processSteps = [
+  {
+    title: "Pulse Check",
+    description:
+      "We audit your channel mix, audience data, and goals to design a hype system that compounds.",
+    duration: "Week 1"
+  },
+  {
+    title: "Blueprint",
+    description:
+      "Collaborative workshops deliver positioning, creative direction, and launch roadmap.",
+    duration: "Weeks 2-3"
+  },
+  {
+    title: "Production Sprint",
+    description:
+      "We orchestrate creative, partners, talent, and ops while your team stays in the loop with async updates.",
+    duration: "Weeks 4-7"
+  },
+  {
+    title: "Launch & Amplify",
+    description:
+      "Experiences go live with parallel digital plays, followed by real-time optimization and reporting.",
+    duration: "Weeks 8+"
+  }
+];
+
+export const testimonials = [
+  {
+    quote:
+      "The launch experience drove 34% of our annual revenue in a single quarter. It felt like our brand finally had a heartbeat.",
+    author: "Sasha Kim",
+    role: "VP Marketing, Nova Athletics"
+  },
+  {
+    quote:
+      "Hype Em Up turned a product beta into a cultural moment. Investors, users, press — everyone was talking about it.",
+    author: "Marco Chen",
+    role: "Founder, PulsePay"
+  },
+  {
+    quote:
+      "Their dashboards made it effortless to report back to leadership. Every dollar was tied to pipeline impact.",
+    author: "Priya Desai",
+    role: "Head of Growth, Lumen Labs"
+  }
+];
+
+export const pricingTiers = [
+  {
+    name: "Launch Lab",
+    price: "$18k",
+    description: "For seed to Series A teams validating new positioning or product lines.",
+    items: [
+      "Narrative + GTM architecture",
+      "Rapid creative and asset kit",
+      "Virtual or pop-up activation"
+    ]
+  },
+  {
+    name: "Momentum",
+    price: "$42k",
+    description: "Scale multi-city or hybrid experiences to accelerate pipeline and press.",
+    items: [
+      "Full-service experiential production",
+      "Influencer and partner orchestration",
+      "Lifecycle nurture & conversion flows"
+    ],
+    highlighted: true
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    description: "Dedicated team for global campaigns with compliance and localization needs.",
+    items: [
+      "Always-on hype pods",
+      "Global vendor management",
+      "Executive reporting suite"
+    ]
+  }
+];
+
+export const faqs = [
+  {
+    question: "What types of brands do you partner with?",
+    answer:
+      "We collaborate with product-led startups and modern enterprises launching new narratives, flagship drops, or community-driven campaigns. Most of our partners are Series A+ with in-house marketing teams."
+  },
+  {
+    question: "How far in advance should we engage?",
+    answer:
+      "We recommend starting 8-10 weeks before launch to align on strategy, secure venues or partners, and build the companion digital funnel. For fast-moving drops we offer an accelerated 4-week sprint."
+  },
+  {
+    question: "Can you integrate with our existing tools?",
+    answer:
+      "Yes. We connect activation data into HubSpot, Salesforce, Marketo, and custom data warehouses so your team has a single source of truth."
+  },
+  {
+    question: "Do you offer post-launch support?",
+    answer:
+      "Every engagement includes performance reporting, learnings, and optional retainers for ongoing campaigns."
+  }
+];

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "hypeemup",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@headlessui/react": "^2.1.4",
+    "@heroicons/react": "^2.1.5",
+    "clsx": "^2.1.1",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.8",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@headlessui/react": "^2.1.4",
     "@heroicons/react": "^2.1.5",
-    "clsx": "^2.1.1",
     "next": "^14.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/case-nova.svg
+++ b/public/case-nova.svg
@@ -1,0 +1,20 @@
+<svg width="800" height="520" viewBox="0 0 800 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="520" rx="32" fill="#101022"/>
+  <rect x="60" y="60" width="320" height="200" rx="24" fill="url(#gradient1)"/>
+  <rect x="420" y="60" width="320" height="200" rx="24" fill="url(#gradient2)"/>
+  <rect x="60" y="300" width="680" height="160" rx="24" fill="#161638"/>
+  <text x="90" y="340" fill="white" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="32" font-weight="700">Nova Athletics Pop-Up</text>
+  <text x="90" y="380" fill="#C9C7FF" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="18" font-weight="500">
+    Sold out 12k units in 36 hours. 18k net-new subscribers captured on-site.
+  </text>
+  <defs>
+    <linearGradient id="gradient1" x1="60" y1="60" x2="380" y2="260" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#2E2E59"/>
+    </linearGradient>
+    <linearGradient id="gradient2" x1="420" y1="60" x2="740" y2="260" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF6B6B"/>
+      <stop offset="1" stop-color="#321823"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/case-pulse.svg
+++ b/public/case-pulse.svg
@@ -1,0 +1,22 @@
+<svg width="800" height="520" viewBox="0 0 800 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="520" rx="32" fill="#0F1628"/>
+  <rect x="60" y="80" width="680" height="160" rx="24" fill="#162B4E"/>
+  <rect x="60" y="280" width="320" height="160" rx="24" fill="url(#pulseGradient)"/>
+  <rect x="420" y="280" width="320" height="160" rx="24" fill="#162B4E"/>
+  <text x="90" y="140" fill="#9BD2FF" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="26" font-weight="600">
+    PulsePay Founders Circle
+  </text>
+  <text x="90" y="180" fill="white" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="18" font-weight="500">
+    2x qualified pipeline. 40% faster enterprise close rate.
+  </text>
+  <text x="90" y="340" fill="white" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="24" font-weight="700">VIP Beta Lounge</text>
+  <text x="450" y="340" fill="#C9E7FF" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="18" font-weight="500">
+    Instrumented experiences with QR-to-CRM capture and live dashboards.
+  </text>
+  <defs>
+    <linearGradient id="pulseGradient" x1="60" y1="280" x2="380" y2="440" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3BC9F6"/>
+      <stop offset="1" stop-color="#1B3B84"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/og.svg
+++ b/public/og.svg
@@ -1,0 +1,36 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" rx="48" fill="#050510"/>
+  <circle cx="240" cy="180" r="220" fill="url(#paint0_radial)" fill-opacity="0.8"/>
+  <circle cx="960" cy="480" r="260" fill="url(#paint1_radial)" fill-opacity="0.7"/>
+  <g filter="url(#filter0_d)">
+    <path d="M252 216C252 159.88 284.012 124 336.124 124C388.236 124 420.25 159.88 420.25 216V414H362.628V222.448C362.628 200.784 351.092 187.892 336.124 187.892C321.156 187.892 309.62 200.784 309.62 222.448V414H252V216Z" fill="white"/>
+    <path d="M450.41 414V126H507.32V414H450.41Z" fill="white"/>
+    <path d="M539.207 126H687.931C742.671 126 780.971 160.316 780.971 212.272C780.971 250.204 759.307 281.628 725.699 294.52L786.791 414H720.671L665.443 301.116H596.117V414H539.207V126ZM681.335 246.996C700.139 246.996 712.275 231.42 712.275 212.272C712.275 193.124 700.139 179.788 681.335 179.788H596.117V246.996H681.335Z" fill="white"/>
+  </g>
+  <text x="120" y="480" fill="#C9C7FF" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="42" font-weight="500">
+    Experiential marketing studio turning product launches into unforgettable movements.
+  </text>
+  <text x="120" y="540" fill="white" font-family="'Manrope', 'Helvetica Neue', sans-serif" font-size="28" font-weight="700">
+    hypeemup.com
+  </text>
+  <defs>
+    <filter id="filter0_d" x="232" y="106" width="576" height="328" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.369 0 0 0 0 0.337 0 0 0 0 0.902 0 0 0 0.3 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 180) rotate(90) scale(220)">
+      <stop stop-color="#6C5CE7"/>
+      <stop offset="1" stop-color="#6C5CE7" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 480) rotate(90) scale(260)">
+      <stop stop-color="#FF6B6B"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,42 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./lib/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#6C5CE7",
+          foreground: "#ffffff"
+        },
+        accent: {
+          DEFAULT: "#FF6B6B",
+          foreground: "#ffffff"
+        }
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)"]
+      },
+      boxShadow: {
+        glow: "0 0 40px rgba(108, 92, 231, 0.3)"
+      },
+      keyframes: {
+        fadeIn: {
+          "0%": { opacity: "0", transform: "translateY(-4px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" }
+        }
+      },
+      animation: {
+        fadeIn: "fadeIn 0.3s ease-out forwards"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 + Tailwind CSS application structure for hypeemup.com
- build hero, capabilities, process, testimonials, pricing, FAQ, CTA, and contact sections with data-driven components
- add newsletter/contact API endpoint with validation and create branded SVG assets for open graph and case studies

## Testing
- unable to run tests: `npm install` blocked by registry proxy (403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68d0a56cda8083208651c139bd6a5efe